### PR TITLE
Added support for clt,r30b1 and build fixes

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
+++ b/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
@@ -25,7 +25,7 @@
     chosen {
         stdout-path = "serial0:115200n8";
 		// bootargs-append = "console=ttyS0,115200n1";
-		bootargs = "console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000 ubi.mtd=ubi root=ubi0:rootfs rootfstype=squashfs";
+		bootargs = "console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000 ubi.mtd=ubi";
 	};
 
 

--- a/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
+++ b/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
@@ -25,7 +25,7 @@
     chosen {
         stdout-path = "serial0:115200n8";
 		// bootargs-append = "console=ttyS0,115200n1";
-		bootargs = "console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000,root=/dev/fit0";
+		bootargs = "console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000 ubi.mtd=ubi root=ubi0:rootfs rootfstype=squashfs";
 	};
 
 
@@ -233,22 +233,19 @@
 				read-only;
 			};
 
+			// FIXED: Match immortalwrt-112m layout from U-Boot
 			partition@580000 {
 				label = "ubi";
-				reg = <0x0580000 0x4000000>;
-				compatible = "linux,ubi";
-
-				volumes {
-					ubi_rootdisk: ubi-volume-fit {
-						volname = "fit";
-					};
-				};
+				reg = <0x0580000 0x7000000>;
 			};
 
+			// REMOVED: data partition doesn't exist in immortalwrt-112m layout
+			/*
 			partition@4580000 {
 				label = "data";
 				reg = <0x4580000 0x2000000>;
 			};
+			*/
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
+++ b/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
@@ -87,72 +87,24 @@
 		};
 	};
 
-// comment out as assuming wan port is on the MT7531
-/*	gmac1: mac@1 {
+	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
 		phy-mode = "gmii";
 		phy-handle = <&int_gbe_phy>;
-	};*/
-
-	mdio: mdio-bus {
-		compatible = "mediatek,ethsys-mdio";
-		#address-cells = <1>;
-		#size-cells = <0>;
 	};
+
 };
 
 &mdio_bus {
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
-		reg = <0x1f>;
-		/* Reset GPIO polarity might differ, check board schematics if possible. Assuming ACTIVE_HIGH based on template */
+		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;
 		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
-		status = "okay";
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-				label = "lan1";
-			};
-
-			port@1 {
-				reg = <1>;
-				label = "lan2";
-			};
-
-			port@2 {
-				reg = <2>;
-				label = "lan3";
-			};
-
-			wan: port@3 {
-				reg = <3>;
-				label = "wan";
-				/* MAC address from factory if available */
-				nvmem-cell-names = "mac-address";
-				nvmem-cells = <&macaddr_factory_4 (-2)>;
-			};
-
-			port@6 {
-				reg = <6>;
-				ethernet = <&gmac0>;
-				phy-mode = "2500base-x";
-
-				fixed-link {
-					speed = <2500>;
-					full-duplex;
-					pause;
-				};
-			};
-		};
 	};
 };
 
@@ -246,6 +198,40 @@
 				reg = <0x4580000 0x2000000>;
 			};
 			*/
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
+++ b/target/linux/mediatek/dts/mt7981b-edup-rt2980.dts
@@ -5,7 +5,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
 
-#include "mt7981.dtsi"
+#include "mt7981b.dtsi"
 
 / {
     model = "EDUP RT2980";

--- a/target/linux/mediatek/dts/mt7981b-edup-rt2980n.dts
+++ b/target/linux/mediatek/dts/mt7981b-edup-rt2980n.dts
@@ -5,7 +5,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
 
-#include "mt7981.dtsi"
+#include "mt7981b.dtsi"
 
 / {
 	model = "EDUP RT2980 Non-OpenWrt";

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -165,6 +165,7 @@ mediatek_setup_macs()
 
 	case $board in
 	edup,rt2980)
+		local part_name="Factory"
 		lan_mac=$(mtd_get_mac_binary $part_name 0x2A)
 		wan_mac=$(mtd_get_mac_binary $part_name 0x24)
 		label_mac=$lan_mac

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -10,6 +10,8 @@ mediatek_setup_interfaces()
 	case $board in
 	abt,asr3000|\
 	cmcc,rax3000m|\
+        edup,rt2980|\
+        edup,rt2980n|\
 	h3c,magic-nx30-pro|\
 	netis,nx31|\
 	nokia,ea0326gmp|\
@@ -31,8 +33,6 @@ mediatek_setup_interfaces()
 	arcadyan,mozart)
 		ucidef_set_interfaces_lan_wan "lan0 eth1" eth2
 		;;
-	edup,rt2980|\
-	edup,rt2980n|\
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,zenwifi-bt8|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -124,6 +124,7 @@ define Device/edup_rt2980
   DEVICE_DTS := mt7981b-edup-rt2980
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-mt76
+  SUPPORTED_DEVICES := edup,rt2980 clt,r30b1
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048


### PR DESCRIPTION
Added support for clt,r30b1 in device definition (tested no error on sysupgrade checks).
Minor fixes for build to be done: renamed 7981b.dtsi